### PR TITLE
Add support for region

### DIFF
--- a/classes/amazon-web-services.php
+++ b/classes/amazon-web-services.php
@@ -137,6 +137,14 @@ class Amazon_Web_Services extends AWS_Plugin_Base {
 		return $this->get_setting( 'access_key_id' );
 	}
 
+	function get_region() {
+		if ( defined('AWS_REGION') ) {
+			return AWS_REGION;
+		}
+
+		return null;
+	}
+
 	function get_secret_access_key() {
 		if ( $this->are_key_constants_set() ) {
 			return AWS_SECRET_ACCESS_KEY;
@@ -155,6 +163,11 @@ class Amazon_Web_Services extends AWS_Plugin_Base {
 			    'key'    => $this->get_access_key_id(),
 			    'secret' => $this->get_secret_access_key()
 			);
+
+			if ( $this->get_region() ) {
+				$args['region'] = $this->get_region();
+			}
+
 			$args = apply_filters( 'aws_get_client_args', $args );
 			$this->client = Aws::factory( $args );
 		}


### PR DESCRIPTION
Let users create a AWS_REGION named constant in PHP in order to create the Aws::factory with it. Useful for all S3 buckets in regions other than default, where it might need to be appended to the URL or even the API might reject some PUT requests.
