### PR TITLE
Fixing fatal error by loading plugin files if we are migrating from old plugin

### DIFF
--- a/amazon-web-services.php
+++ b/amazon-web-services.php
@@ -36,12 +36,15 @@ if ( $aws_compat_check->is_compatible() ) {
 	add_action( 'init', 'amazon_web_services_init' );
 }
 
-function amazon_web_services_init() {
+function amazon_web_services_require_files() {
 	$abspath = dirname( __FILE__ );
 	require_once $abspath . '/classes/aws-plugin-base.php';
 	require_once $abspath . '/classes/amazon-web-services.php';
 	require_once $abspath . '/vendor/aws/aws-autoloader.php';
+}
 
+function amazon_web_services_init() {
+	amazon_web_services_require_files();
 	global $amazon_web_services;
 	$amazon_web_services = new Amazon_Web_Services( __FILE__ );
 }
@@ -62,6 +65,8 @@ function amazon_web_services_activation() {
 	if ( ! isset( $as3cf['key'] ) || ! isset( $as3cf['secret'] ) ) {
 		return;
 	}
+
+	amazon_web_services_require_files();
 
 	if ( ! get_site_option( Amazon_Web_Services::SETTINGS_KEY ) ) {
 		add_site_option( Amazon_Web_Services::SETTINGS_KEY, array(


### PR DESCRIPTION
When migrating `tantan_wordpress_s3` settings on plugin activation

Resolves #50 
