### PR TITLE
Features/allows server roles

### DIFF
--- a/classes/amazon-web-services.php
+++ b/classes/amazon-web-services.php
@@ -233,13 +233,13 @@ class Amazon_Web_Services extends AWS_Plugin_Base {
 		}
 
 		if ( is_null( $this->client ) ) {
+			$args = array();
 			if (strpos($this->get_access_key_id(), 'AKI', 0)) {
 				$args = array(
 					'key'       => $this->get_access_key_id(),
 					'secret'    => $this->get_secret_access_key(),
 				);
 			}
-
 			$args         = apply_filters( 'aws_get_client_args', $args );
 			$this->client = Aws::factory( $args );
 		}

--- a/classes/amazon-web-services.php
+++ b/classes/amazon-web-services.php
@@ -229,14 +229,16 @@ class Amazon_Web_Services extends AWS_Plugin_Base {
 	 */
 	function get_client() {
 		if ( ! $this->get_access_key_id() || ! $this->get_secret_access_key() ) {
-			return new WP_Error( 'access_keys_missing', sprintf( __( 'You must first <a href="%s">set your AWS access keys</a> to use this addon.', 'amazon-web-services' ), 'admin.php?page=' . $this->plugin_slug ) ); // xss ok
+			return new WP_Error( 'access_keys_missing', sprintf( __( 'You must first <a href="%s">set your AWS access keys</a> to use this addon. If the key you entered is not starting with with \'AKI\', it will attempt to use instance roles instead', 'amazon-web-services' ), 'admin.php?page=' . $this->plugin_slug ) ); // xss ok
 		}
 
 		if ( is_null( $this->client ) ) {
-			$args = array(
-				'key'       => $this->get_access_key_id(),
-				'secret'    => $this->get_secret_access_key(),
-			);
+			if (strpos($this->get_access_key_id(), 'AKI', 0)) {
+				$args = array(
+					'key'       => $this->get_access_key_id(),
+					'secret'    => $this->get_secret_access_key(),
+				);
+			}
 
 			$args         = apply_filters( 'aws_get_client_args', $args );
 			$this->client = Aws::factory( $args );


### PR DESCRIPTION
If the application is running on Amazon EC2, using server roles allows to not have to store keys on the server or in the database. Also see https://github.com/deliciousbrains/wp-amazon-web-services/issues/41